### PR TITLE
chore/gh pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy GDG Konkuk Landing Page to Pages
+
+on:
+  # main 브랜치에 푸시될 때 워크플로우를 실행합니다.
+  push:
+    branches: ["main"]
+  # Actions 탭에서 수동으로 이 워크플로우를 실행할 수 있게 합니다.
+  workflow_dispatch:
+
+# GITHUB_TOKEN의 권한을 설정하여 배포를 허용합니다.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  # 빌드 작업
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8 # 사용하는 pnpm 버전에 맞게 설정
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18" # 프로젝트의 Node.js 버전에 맞게 설정
+          cache: 'pnpm' # pnpm 캐시 설정
+      - name: Install dependencies
+        run: pnpm install # 의존성 설치
+      - name: Build with Next.js
+        run: pnpm build # 정적 파일 빌드
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Next.js의 정적 빌드 결과물인 'out' 폴더를 업로드합니다.
+          path: ./out
+
+  # 배포 작업
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  basePath: '/landing-page',
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
### 📎 Title
Setup GitHub Pages deployment for GDG Konkuk Landing Page

### 📃 Changes
- **Added GitHub Actions workflow** (`.github/workflows/deploy.yml`):
  - Automated deployment pipeline for GitHub Pages
  - Configured to trigger on push to `main` branch and manual workflow dispatch
  - Set up build job using pnpm for dependency management and Next.js static export
  - Configured deploy job with proper GitHub Pages environment settings

- **Updated Next.js configuration** (`next.config.mjs`):
  - Added `output: 'export'` for static site generation
  - Set `basePath: '/landing-page'` for GitHub Pages subdirectory hosting
  - Added `images.unoptimized: true` to support static export

- **Project structure optimization**:
  - Configured for static hosting with proper asset handling
  - Set up for GitHub Pages deployment workflow

### 🫨 Considerations
- The workflow uses pnpm as the package manager (version 8) instead of npm or yarn
- Node.js version is set to 18 for compatibility
- The build output directory is set to `./out` as per Next.js static export convention
- Repository permissions are configured to allow GitHub Pages deployment
- The deployment is set up for the `/landing-page` base path, suggesting this will be hosted as a subdirectory

### 📌 Important
- **Deployment trigger**: Automatic deployment occurs on every push to the `main` branch
- **Manual deployment**: Available through GitHub Actions tab using `workflow_dispatch`
- **Build artifacts**: Static files are generated in the `out` directory
- **Base path**: Site will be accessible at `{username}.github.io/landing-page`
- **Dependencies**: Ensure all required packages are properly listed in `package.json`